### PR TITLE
Remove unnecessary call to load snapshot indices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
           when: always
       - run:
           name: Execute mocha tests
-          command: ./node_modules/.bin/nyc ./node_modules/.bin/mocha --reporter mocha-junit-reporter --reporter-options mochaFile=test-results/mocha/test-results.xml
+          command: ./node_modules/.bin/nyc --silent ./node_modules/.bin/mocha --reporter mocha-junit-reporter --reporter-options mochaFile=test-results/mocha/test-results.xml
           when: always
       - run:
           name: Publish code coverage
-          command: ./node_modules/.bin/nyc --reporter=html --check-coverage
+          command: ./node_modules/.bin/nyc report --reporter=html --check-coverage
           when: always
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,23 @@ jobs:
       - node/with-cache:
           steps:
             - run:
-                name: Install NPM
+                name: Install npm packages
                 command: npm install
+            - run:
+                name: Install mocha junit reporter
+                command: npm install mocha-junit-reporter
       - run:
-          name: Execute Tests
-          command: npm test
+          name: Check Coding Conventions
+          command: ./node_modules/.bin/standard
+          when: always
+      - run:
+          name: Execute mocha tests
+          command: ./node_modules/.bin/nyc ./node_modules/.bin/mocha --reporter mocha-junit-reporter --reporter-options mochaFile=test-results/mocha/test-results.xml
+          when: always
       - run:
           name: Publish code coverage
-          command: npm run coverage
+          command: ./node_modules/.bin/nyc --reporter=html --check-coverage
+          when: always
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Restores all indexes from backup",
   "main": "scan.js",
   "scripts": {
-    "test": "standard && nyc mocha --reporter=xunit --reporter-option output=test-results/mocha/test-results.xml",
+    "test": "standard && nyc mocha",
     "coverage": "nyc report --reporter=html --check-coverage"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "author": "Aaron Weiker <aaron@weiker.org>",
   "name": "elastic-recovery",
   "version": "0.0.1",
-  "description": "Restores all indexes from backup",
+  "description": "Restores all indices from backup",
   "main": "scan.js",
   "scripts": {
-    "test": "standard && nyc mocha",
-    "coverage": "nyc report --reporter=html --check-coverage"
+    "test": "standard && nyc mocha"
   },
   "repository": {
     "type": "git",

--- a/scan.js
+++ b/scan.js
@@ -13,7 +13,7 @@ async function scan (info, repository, pattern, onUpdate) {
   if (onUpdate && typeof (onUpdate) !== 'function') {
     throw new Error('onUpdate should be of type function.')
   }
-  const snapshotPromise = elastic.loadSnapshots(info, repository, 'curator-iis-*2020*')
+  const snapshotPromise = elastic.loadSnapshots(info, repository, pattern)
   const indexPromise = elastic.loadIndices(info)
 
   const foundIndices = []

--- a/scan.js
+++ b/scan.js
@@ -48,7 +48,7 @@ async function scan (info, repository, pattern, onUpdate) {
 
   for (var s = 0; s < snapshots.length; s++) {
     const snapshot = snapshots[s]
-    const snapshotIndices = await elastic.loadSnapshotIndices(info, repository, snapshot)
+    const snapshotIndices = snapshot.indices
 
     var foundSnapshotIndexes = []
     for (var i = 0; i < snapshotIndices.length; i++) {
@@ -60,11 +60,11 @@ async function scan (info, repository, pattern, onUpdate) {
     }
 
     if (foundSnapshotIndexes.length > 0) {
-      await trackFoundIndex(foundSnapshotIndexes, repository, snapshot)
+      await trackFoundIndex(foundSnapshotIndexes, repository, snapshot.name)
     }
 
     if (onUpdate) {
-      onUpdate(`${snapshot} - added ${foundSnapshotIndexes.length}/${snapshotIndices.length}`)
+      onUpdate(`${snapshot.name} - added ${foundSnapshotIndexes.length}/${snapshotIndices.length}`)
     }
   }
 

--- a/test/scan_test.js
+++ b/test/scan_test.js
@@ -11,13 +11,12 @@ function _setupElasticMock (snapshots) {
   const elasticMock = {
     loadSnapshots: async function (...args) {
       elasticMock.__loadSnapshots.push(args)
-      return Object.keys(snapshots)
+      return Object.keys(snapshots).map(s => {
+        return { name: s, indices: snapshots[s] }
+      })
     },
     loadIndices: async function () {
       return []
-    },
-    loadSnapshotIndices: async function (_info, _repository, snapshot) {
-      return snapshots[snapshot]
     },
     restoreIndexFromSnapshot: async function (...args) {
       elasticMock.__restoreIndexFromSnapshot.push(args)

--- a/test/scan_test.js
+++ b/test/scan_test.js
@@ -53,6 +53,16 @@ describe('Scan', function () {
       }, result)
     })
 
+    it('should use pattern for filtering snapshots', async function () {
+      const mock = _setupElasticMock({
+        's-1': ['i-1', 'i-2', 'i-3']
+      })
+
+      await sut.scan({}, 'my-repository', 's-*')
+
+      assert.strictEqual('s-*', mock.__loadSnapshots[0][2])
+    })
+
     it('should halt if no snapshots are found', async function () {
       _setupElasticMock({ })
 


### PR DESCRIPTION
Fixes #5 by tracking the indices on each snapshot as they are returned by the original lookup to list snapshots.