### PR TITLE
Remove unnecessary call to load snapshot indices

### DIFF
--- a/scan.js
+++ b/scan.js
@@ -48,7 +48,7 @@ async function scan (info, repository, pattern, onUpdate) {
 
   for (var s = 0; s < snapshots.length; s++) {
     const snapshot = snapshots[s]
-    const snapshotIndices = await elastic.loadSnapshotIndices(info, repository, snapshot)
+    const snapshotIndices = snapshot.indices
 
     var foundSnapshotIndexes = []
     for (var i = 0; i < snapshotIndices.length; i++) {
@@ -60,11 +60,11 @@ async function scan (info, repository, pattern, onUpdate) {
     }
 
     if (foundSnapshotIndexes.length > 0) {
-      await trackFoundIndex(foundSnapshotIndexes, repository, snapshot)
+      await trackFoundIndex(foundSnapshotIndexes, repository, snapshot.name)
     }
 
     if (onUpdate) {
-      onUpdate(`${snapshot} - added ${foundSnapshotIndexes.length}/${snapshotIndices.length}`)
+      onUpdate(`${snapshot.name} - added ${foundSnapshotIndexes.length}/${snapshotIndices.length}`)
     }
   }
 

--- a/test/scan_test.js
+++ b/test/scan_test.js
@@ -11,13 +11,12 @@ function _setupElasticMock (snapshots) {
   const elasticMock = {
     loadSnapshots: async function (...args) {
       elasticMock.__loadSnapshots.push(args)
-      return Object.keys(snapshots)
+      return Object.keys(snapshots).map(s => {
+        return { name: s, indices: snapshots[s] }
+      })
     },
     loadIndices: async function () {
       return []
-    },
-    loadSnapshotIndices: async function (_info, _repository, snapshot) {
-      return snapshots[snapshot]
     },
     restoreIndexFromSnapshot: async function (...args) {
       elasticMock.__restoreIndexFromSnapshot.push(args)


### PR DESCRIPTION
Fixes #6 by tracking the indices on each snapshot as they are returned by the original lookup to list snapshots.